### PR TITLE
Fixed maven-install with grails 2.4.2, Added configurable tempUsage and soreUsage

### DIFF
--- a/ActivemqGrailsPlugin.groovy
+++ b/ActivemqGrailsPlugin.groovy
@@ -45,10 +45,24 @@ class ActivemqGrailsPlugin {
 
     println '\nActiveMQ Embedded...'
 
+    jmsTempUsage(org.apache.activemq.usage.TempUsage) {
+      limit = conf?.tempUsage?.limit ?: 64 * 1024 * 1024
+    }
+
+    jmsStoreUsage(org.apache.activemq.usage.StoreUsage) {
+      limit = conf?.storeUsage?.limit ?: 64 * 1024 * 1024
+    }
+
+    jmsSystemUsage(org.apache.activemq.usage.SystemUsage) {
+      tempUsage = ref("jmsTempUsage")
+      storeUsage = ref("jmsStoreUsage")
+    }
+
     jmsBroker(org.apache.activemq.xbean.XBeanBrokerService) {
       useJmx = conf?.useJmx ?: true
       persistent = conf?.persistent ?: true
       def port = conf?.port ?: 61616
+      systemUsage = ref("jmsSystemUsage")
       transportConnectors = [new org.apache.activemq.broker.TransportConnector(uri: new URI("tcp://localhost:${port}"))]
     }
 

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -21,7 +21,9 @@ grails.project.target.level = 1.6
 
 def activemqVersion = '5.7.0'
 
+grails.project.dependency.resolver = "maven" // or ivy
 grails.project.dependency.resolution = {
+  legacyResolve true
   // inherit Grails' default dependencies
   inherits("global") {
     // uncomment to disable ehcache
@@ -31,10 +33,7 @@ grails.project.dependency.resolution = {
   repositories {
     mavenLocal()
     mavenCentral()
-    grailsPlugins()
-    grailsHome()
     grailsCentral()
-    grailsRepo "http://grails.org/plugins"
     mavenRepo "http://repo.grails.org/grails/plugins"
     mavenRepo "http://download.java.net/maven/2/"
     mavenRepo "http://repository.jboss.org/nexus/content/groups/public-jboss/"
@@ -57,9 +56,10 @@ grails.project.dependency.resolution = {
   }
 
   plugins {
-      build(":release:2.1.0") { export = false }
-      build(":rest-client-builder:1.0.2") { export = false }
-      build(":tomcat:$grailsVersion") { export = false }
+      build(":release:3.0.1",
+              ":rest-client-builder:1.0.3") {
+          export = false
+      }
   }
 }
 


### PR DESCRIPTION
Fixed dependencies resolution in BuildConfig so it properly does a maven-install with grails 2.4.2

Added configurable tempUsage.limit and storeUsage.limit, and set default for both to 64Mb
